### PR TITLE
Allow an app to pass an existing redis connection to the blueprint

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -58,34 +58,31 @@ blueprint = Blueprint(
 )
 
 
+@blueprint.record_once
+def init_blueprint(state):
+    if "redis_connection" in state.options:
+        state.app.redis_conn = state.options["redis_connection"]
+
+
 @blueprint.before_app_first_request
 def setup_rq_connection():
-    # we need to do It here instead of cli, since It may be embeded
-    upgrade_config(current_app)
-    # Getting Redis connection parameters for RQ
-    redis_url = current_app.config.get("RQ_DASHBOARD_REDIS_URL")
-    if isinstance(redis_url, string_types):
-        current_app.config["RQ_DASHBOARD_REDIS_URL"] = (redis_url,)
-        _, current_app.redis_conn = from_url((redis_url,)[0])
-    elif isinstance(redis_url, (tuple, list)):
-        _, current_app.redis_conn = from_url(redis_url[0])
-    else:
-        raise RuntimeError("No Redis configuration!")
+    if current_app.redis_conn is None:
+        # we need to do It here instead of cli, since It may be embeded
+        upgrade_config(current_app)
+        # Getting Redis connection parameters for RQ
+        redis_url = current_app.config.get("RQ_DASHBOARD_REDIS_URL")
+        if isinstance(redis_url, string_types):
+            current_app.config["RQ_DASHBOARD_REDIS_URL"] = (redis_url,)
+            _, current_app.redis_conn = from_url((redis_url,)[0])
+        elif isinstance(redis_url, (tuple, list)):
+            _, current_app.redis_conn = from_url(redis_url[0])
+        else:
+            raise RuntimeError("No Redis configuration!")
 
 
 @blueprint.before_request
 def push_rq_connection():
-    new_instance_number = request.view_args.get("instance_number")
-    if new_instance_number is not None:
-        redis_url = current_app.config.get("RQ_DASHBOARD_REDIS_URL")
-        if new_instance_number < len(redis_url):
-            _, new_instance = from_url(redis_url[new_instance_number])
-        else:
-            raise LookupError("Index exceeds RQ list. Not Permitted.")
-    else:
-        new_instance = current_app.redis_conn
-    push_connection(new_instance)
-    current_app.redis_conn = new_instance
+    push_connection(current_app.redis_conn)
 
 
 @blueprint.teardown_request


### PR DESCRIPTION
Because we will be using automatic password rotation on Elasticache / Redis, the password may change while the app is running. An existing session would not be impacted but since we are using a connection pool there are different reasons why a new connection could be created at any moment - potentially with stale credentials since they are statically set in the REDIS_URL.

We handle this via a custom `Connection` class on `alan-backend` and we need to pass this connection (or rather connection pool) to `rq-dashboard` (otherwise it uses a static RQ_DASHBOARD_REDIS_URL)

Since we're not using it and because it would complicate the changes, I chose to remove support for multiple Redis connections.